### PR TITLE
Link libatomic on riscv64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ include options.mk
 CFLAGS += -Isrc/include
 CXXFLAGS += -Isrc/include
 
+ifeq ($(shell uname -m),riscv64)
+LDFLAGS += -latomic
+endif
+
 PREFIX ?= /usr/local
 
 all: main


### PR DESCRIPTION
This fixes build errors on riscv64 due to missing sub-word atomics, as seen in Debian buildd log ([full](https://buildd.debian.org/status/fetch.php?pkg=swirc&arch=riscv64&ver=3.3.8-1.1&stamp=1670449248&raw=0)):

```
In file included from src/tls-server.h:4,
                 from src/tls-server.cpp:47:
/usr/include/openssl/ssl.h:2227:6: note: declared here
 2227 | void SSL_CTX_set_tmp_dh_callback(SSL_CTX *ctx,
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
  LINK     swirc
/usr/bin/ld: src/network.o: in function `reconnect_context::init()':
/<<PKGBUILDDIR>>/src/network.cpp:92: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: src/network.o: in function `.L0 ':
/<<PKGBUILDDIR>>/src/network.cpp:555: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: /<<PKGBUILDDIR>>/src/network.cpp:425: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: src/network.o: in function `net_connect':
/<<PKGBUILDDIR>>/src/network.cpp:534: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: src/network.o: in function `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_check_length(unsigned long, unsigned long, char const*) const':
/usr/include/c++/12/bits/basic_string.h:393: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: src/network.o:/<<PKGBUILDDIR>>/src/network.cpp:543: more undefined references to `__atomic_exchange_1' follow
collect2: error: ld returned 1 exit status
```

Other platforms may need to link against libatomic as well, and they can be added later.